### PR TITLE
Add StateCode support to OptionSetHandler

### DIFF
--- a/src/js/Translator/OptionSetHandler.js
+++ b/src/js/Translator/OptionSetHandler.js
@@ -231,15 +231,21 @@
             queryParams: "/Attributes/Microsoft.Dynamics.CRM.StatusAttributeMetadata?$expand=OptionSet,GlobalOptionSet"
         };
 
+        var stateRequest = {
+            entityName: "EntityDefinition",
+            entityId: entityMetadataId,
+            queryParams: "/Attributes/Microsoft.Dynamics.CRM.StateAttributeMetadata?$expand=OptionSet,GlobalOptionSet"
+        };
+
         var multiOptionSetRequest = {
             entityName: "EntityDefinition",
             entityId: entityMetadataId,
             queryParams: "/Attributes/Microsoft.Dynamics.CRM.MultiSelectPicklistAttributeMetadata?$expand=OptionSet,GlobalOptionSet"
         };
 
-        return WebApiClient.Promise.all([WebApiClient.Retrieve(optionSetRequest), WebApiClient.Retrieve(booleanRequest), WebApiClient.Retrieve(statusRequest), WebApiClient.Retrieve(multiOptionSetRequest)])
+        return WebApiClient.Promise.all([WebApiClient.Retrieve(optionSetRequest), WebApiClient.Retrieve(booleanRequest), WebApiClient.Retrieve(statusRequest), WebApiClient.Retrieve(stateRequest), WebApiClient.Retrieve(multiOptionSetRequest)])
             .then(function(responses){
-                var responseValues = responses[0].value.concat(responses[1].value).concat(responses[2].value).concat(responses[3].value);
+                var responseValues = responses[0].value.concat(responses[1].value).concat(responses[2].value).concat(responses[3].value).concat(responses[4].value);
                 var attributes = responseValues.sort(XrmTranslator.SchemaNameComparer);
 
                 XrmTranslator.metadata = attributes;


### PR DESCRIPTION
## Summary
- Add `StateAttributeMetadata` retrieval to `OptionSetHandler.js` so that **StateCode** option set values can be translated alongside existing PicklistAttribute, BooleanAttribute, StatusAttribute, and MultiSelectPicklistAttribute.

## Changes
- Added `stateRequest` to query `StateAttributeMetadata` with `OptionSet` and `GlobalOptionSet` expansion
- Included the new request in `Promise.all` and concatenated results into the attributes list

## Test plan
- [ ] Open Xrm Quick Edit in a Dynamics 365 environment
- [ ] Navigate to an entity that has a StateCode field
- [ ] Verify StateCode option set values appear in the translation grid
- [ ] Verify existing option set types (Picklist, Boolean, Status, MultiSelect) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)